### PR TITLE
Change delete confirmation window logic

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,6 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX = "The patient index provided is invalid";
     public static final String MESSAGE_INVALID_WARD_DISPLAYED_INDEX = "The ward index provided is invalid";
     public static final String MESSAGE_DELETE_WAITING_ROOM = "The Waiting Room cannot be deleted";
+    public static final String MESSAGE_ABORT_DELETE = "Deletion cancelled";
 
     public static final String MESSAGE_DELETE_WARD_WITH_PATIENTS =
             "The ward cannot be deleted as there are patients inside";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,10 +2,16 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.commons.core.Messages.MESSAGE_ABORT_DELETE;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javafx.scene.control.Alert;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddWardCommand;
 import seedu.address.logic.commands.ClearCommand;
@@ -45,6 +51,11 @@ public class AddressBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
+        // for confirmation window
+        Alert confirmationDialog;
+        Optional<ButtonType> result;
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
@@ -54,10 +65,24 @@ public class AddressBookParser {
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+            confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
+                    "Are you sure you want to delete the patient?");
+            result = confirmationDialog.showAndWait();
+            if (result.isPresent() && result.get() == ButtonType.OK) {
+                return new DeleteCommandParser().parse(arguments);
+            } else {
+                throw new ParseException(MESSAGE_ABORT_DELETE); // cancel the deletion command
+            }
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
+                    "Are you sure you want to clear ALL patients?");
+            result = confirmationDialog.showAndWait();
+            if (result.isPresent() && result.get() == ButtonType.OK) {
+                return new ClearCommand();
+            } else {
+                throw new ParseException(MESSAGE_ABORT_DELETE); // cancel the deletion command
+            }
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
@@ -75,7 +100,14 @@ public class AddressBookParser {
             return new AddWardCommandParser().parse(arguments);
 
         case DeleteWardCommand.COMMAND_WORD:
-            return new DeleteWardCommandParser().parse(arguments);
+            confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
+                    "Are you sure you want to delete the ward?");
+            result = confirmationDialog.showAndWait();
+            if (result.isPresent() && result.get() == ButtonType.OK) {
+                return new DeleteWardCommandParser().parse(arguments);
+            } else {
+                throw new ParseException(MESSAGE_ABORT_DELETE); // cancel the deletion command
+            }
 
         case SortCommand.COMMAND_WORD:
             return new SortCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 
 import javafx.scene.control.Alert;
 
-import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddWardCommand;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -187,43 +187,6 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
 
-            if (commandText.contains("deleteward")) {
-                Alert confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
-                        "Are you sure you want to delete the ward?");
-                Optional<ButtonType> deleteWardResult = confirmationDialog.showAndWait();
-
-                if (deleteWardResult.isPresent() && deleteWardResult.get() == ButtonType.CANCEL) {
-                    CommandResult commandResult = logic.execute("list");
-                    logger.info("Delete ward aborted: " + commandResult.getFeedbackToUser());
-                    resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-                    return commandResult;
-                }
-            } else if (commandText.contains("delete")) {
-                Alert confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
-                        "Are you sure you want to delete the patient?");
-                Optional<ButtonType> deleteResult = confirmationDialog.showAndWait();
-
-                if (deleteResult.isPresent() && deleteResult.get() == ButtonType.CANCEL) {
-                    CommandResult commandResult = logic.execute("list");
-                    logger.info("Delete aborted: " + commandResult.getFeedbackToUser());
-                    resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-                    return commandResult;
-                }
-            }
-
-            if (commandText.contains("clear")) {
-                Alert confirmationDialog = new Alert(Alert.AlertType.CONFIRMATION,
-                        "Are you sure you want to clear ALL patients?");
-                Optional<ButtonType> clearResult = confirmationDialog.showAndWait();
-
-                if (clearResult.isPresent() && clearResult.get() == ButtonType.CANCEL) {
-                    CommandResult commandResult = logic.execute("list");
-                    logger.info("Clear aborted: " + commandResult.getFeedbackToUser());
-                    resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-                    return commandResult;
-                }
-            }
-
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());


### PR DESCRIPTION
Previously, the deletion confirmation window would be triggered from within MainWindow.java if either `delete`, `deleteward` or `clear` were present in the entered command string. This led to a bug where the confirmation window would be triggered by adding patients or wards named "delete".

By moving the logic to AddressBookParser, we handle this situation by only triggering the confirmation window on the command words entered.

This fix slightly affects the modularity of the code (the confirmation window, UI related, is being raised from a logic-related class), but this seems to be the cleanest way to handle this situation.