### PR TITLE
Make unique ward check case-insensitive

### DIFF
--- a/src/main/java/seedu/medinfo/model/ward/Ward.java
+++ b/src/main/java/seedu/medinfo/model/ward/Ward.java
@@ -209,7 +209,7 @@ public class Ward {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Ward // instanceof handles nulls
-                        && value.wardName.equals(((Ward) other).value.wardName));
+                        && value.equals(((Ward) other).value));
     }
 
     @Override

--- a/src/main/java/seedu/medinfo/model/ward/WardName.java
+++ b/src/main/java/seedu/medinfo/model/ward/WardName.java
@@ -47,7 +47,7 @@ public class WardName {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof WardName // instanceof handles nulls
-                && wardName.equals(((WardName) other).wardName)); // state check
+                && wardName.equalsIgnoreCase(((WardName) other).wardName)); // state check
     }
 
     @Override


### PR DESCRIPTION
Previously, ward uniqueness was based on an exact String match of the Ward Name. Now, we make it check equality while ignoring case so that you cannot have duplicate wards in the system with different case. Also, preserves LoD.